### PR TITLE
infrastructure: add resourcesPreset

### DIFF
--- a/values-ocp-no-aws.yaml
+++ b/values-ocp-no-aws.yaml
@@ -41,6 +41,7 @@ modules:
 
 keycloak:
   enabled: true
+  resourcesPreset: large
   production: true
   proxy: reencrypt
   podSecurityContext:
@@ -65,6 +66,7 @@ keycloak:
       route.openshift.io/termination: reencrypt
   postgresql:
     primary:
+      resourcesPreset: large
       containerSecurityContext:
         enabled: false
       podSecurityContext:


### PR DESCRIPTION
I've faced some issues while testing, especially when during initial keycloak deployment and when importers run with frequent broken connections with the DB hence I've applied the `resourcesPreset` from for those infrastructure helm charts