### PR TITLE
feat: deploy importer as stateless with replicas=2

### DIFF
--- a/charts/trustify/templates/services/importer/030-Deployment.yaml
+++ b/charts/trustify/templates/services/importer/030-Deployment.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.modules.importer.enabled }}
 {{- $mod := dict "root" . "name" "importer" "component" "importer" "module" .Values.modules.importer -}}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "trustification.common.name" $mod }}
   labels:
@@ -10,7 +10,7 @@ metadata:
     {{- include "trustification.application.annotations" $mod | nindent 4 }}
 
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       {{- include "trustification.common.selectorLabels" $mod | nindent 6 }}


### PR DESCRIPTION
Relates trustification/trustify#1207

This matches the number of default enabled importers so that they may be run concurrently.

Ideally, the replicas value would be parameterized, but I'll need some guidance as it's not clear from the code how best to achieve that.

Downstream request: https://issues.redhat.com/browse/TC-2218