### PR TITLE
fix: set some default resources

### DIFF
--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -50,6 +50,10 @@ modules:
     tracing: {}
     metrics: {}
     rust: {}
+    resources:
+      requests:
+        cpu: 1
+        memory: 8Gi
 
   importer:
     enabled: true
@@ -59,6 +63,10 @@ modules:
     tracing: {}
     metrics: {}
     rust: {}
+    resources:
+      requests:
+        cpu: 1
+        memory: 8Gi
     concurrency: 1
     workingDirectory:
       size: 32Gi


### PR DESCRIPTION
Setting some requests, doesn't get pod killed then the nodes get under pressure.