### PR TITLE
TC-2379 Improve podAffinity management

### DIFF
--- a/charts/trustify/templates/helpers/_deployment.tpl
+++ b/charts/trustify/templates/helpers/_deployment.tpl
@@ -44,6 +44,16 @@ Arguments (dict):
 serviceAccountName: {{ . | quote }}
 {{- end }}
 
+{{- end }}
+
+{{/*
+Pod affinity settings
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.application.podAffinity" }}
 affinity:
 {{- with .module.affinity }}
   {{- . | toYaml | nindent 2 }}

--- a/charts/trustify/templates/helpers/_storage.tpl
+++ b/charts/trustify/templates/helpers/_storage.tpl
@@ -109,6 +109,6 @@ podAffinity:
       labelSelector:
         matchLabels:
           {{/* we need to select the "server" pod and align with its host */}}
-          {{- include "trustification.common.selectorLabels" ( merge (deepCopy .) (dict "name" "server" "component" "server") ) | nindent 10 }}
+          {{- include "trustification.common.selectorLabels" ( mergeOverwrite (deepCopy .) (dict "name" "server" "component" "server") ) | nindent 10 }}
 {{- end }}
 {{- end }}

--- a/charts/trustify/templates/services/importer/030-Deployment.yaml
+++ b/charts/trustify/templates/services/importer/030-Deployment.yaml
@@ -22,6 +22,7 @@ spec:
 
     spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
+      {{- include "trustification.application.podAffinity" $mod | nindent 6 }}
 
       containers:
         - name: service

--- a/charts/trustify/templates/services/server/030-Deployment.yaml
+++ b/charts/trustify/templates/services/server/030-Deployment.yaml
@@ -25,6 +25,7 @@ spec:
 
     spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
+      {{- include "trustification.application.podAffinity" $mod | nindent 6 }}
 
       containers:
         - name: service


### PR DESCRIPTION
https://issues.redhat.com/browse/TC-2379

- replaced `merge` with [`mergeOverwrite`](https://helm.sh/docs/chart_template_guide/function_list/#mergeoverwrite-mustmergeoverwrite): the latter works right to left with looks more intuitive to me 
- created a specific `trustification.application.podAffinity` field and applied it only to `server` and `importer` deployment (excluding create and migrate jobs) because they're the only one requiring it AFAIK and "_Inter-pod affinity and anti-affinity require substantial amounts of processing which can slow down scheduling in large clusters significantly_" (ref. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)