### PR TITLE
fix: use new API behavior to detect the identity provider

### DIFF
--- a/charts/trustify-infrastructure/templates/keycloak/020-Job.yaml
+++ b/charts/trustify-infrastructure/templates/keycloak/020-Job.yaml
@@ -139,9 +139,8 @@ spec:
               fi
 
               if [[ -n "$GITHUB_CLIENT_ID" ]]; then
-                ID=$(kcadm get identity-provider/instances/github -r "${REALM}" --fields alias --format csv --noquotes)
-                if [[ -n "$ID" ]]; then
-                  kcadm update "identity-provider/instances/${ID}" -r "${REALM}" -s enabled=true -s 'config.useJwksUrl="true"' -s "config.clientId=$GITHUB_CLIENT_ID" -s "config.clientSecret=$GITHUB_CLIENT_SECRET"
+                if kcadm get identity-provider/instances/github -r "${REALM}" &> /dev/null ; then
+                  kcadm update "identity-provider/instances/github" -r "${REALM}" -s enabled=true -s 'config.useJwksUrl="true"' -s "config.clientId=$GITHUB_CLIENT_ID" -s "config.clientSecret=$GITHUB_CLIENT_SECRET"
                 else
                   kcadm create identity-provider/instances -r "${REALM}" -s alias=github -s providerId=github -s enabled=true -s 'config.useJwksUrl="true"' -s "config.clientId=$GITHUB_CLIENT_ID" -s "config.clientSecret=$GITHUB_CLIENT_SECRET"
                 fi


### PR DESCRIPTION
A recent version of keycloak has changed the identity provider API. So adapts to this change.