### PR TITLE
fix: change argocd hooks to PreSync, allowing pods to start

### DIFF
--- a/charts/trustify-infrastructure/templates/keycloak/020-Job.yaml
+++ b/charts/trustify-infrastructure/templates/keycloak/020-Job.yaml
@@ -4,7 +4,7 @@ apiVersion: batch/v1
 metadata:
   name: post-install-keycloak
   annotations:
-    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "0"
     helm.sh/hook-weight: "10"

--- a/charts/trustify/templates/init/create-database/010-ConfigMap.yaml
+++ b/charts/trustify/templates/init/create-database/010-ConfigMap.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "trustification.common.labels" $mod | nindent 4 }}
   annotations:
     {{- include "trustification.application.annotations" $mod | nindent 4 }}
-    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "0"
     helm.sh/hook-weight: "5"

--- a/charts/trustify/templates/init/create-database/020-Job.yaml
+++ b/charts/trustify/templates/init/create-database/020-Job.yaml
@@ -9,7 +9,7 @@ metadata:
 
   annotations:
     {{- include "trustification.application.annotations" $mod | nindent 4 }}
-    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "0"
     helm.sh/hook-weight: "5"

--- a/charts/trustify/templates/init/create-importers/020-Job.yaml
+++ b/charts/trustify/templates/init/create-importers/020-Job.yaml
@@ -9,7 +9,7 @@ metadata:
 
   annotations:
     {{- include "trustification.application.annotations" $mod | nindent 4 }}
-    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "4"
     helm.sh/hook-weight: "40"

--- a/charts/trustify/templates/init/migrate-database/020-Job.yaml
+++ b/charts/trustify/templates/init/migrate-database/020-Job.yaml
@@ -9,7 +9,7 @@ metadata:
 
   annotations:
     {{- include "trustification.application.annotations" $mod | nindent 4 }}
-    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-wave: "3"
     helm.sh/hook-weight: "20"


### PR DESCRIPTION
Having them as Sync prevents pods to start, as the database is not set up yet. PreSync should fix this.