### PR TITLE
chore(infrastructure): Update OTELCOL to 0.127.0

### DIFF
--- a/charts/trustify-infrastructure/Chart.lock
+++ b/charts/trustify-infrastructure/Chart.lock
@@ -13,6 +13,6 @@ dependencies:
   version: 27.1.0
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.111.1
-digest: sha256:9b5434e2fb770194b9c01020870222f1dc1ad7152925860a8fd13f5d32120994
-generated: "2025-02-11T17:58:39.821476902-03:00"
+  version: 0.126.0
+digest: sha256:984a7719e48dfb7a2a285bc6b9d15a635f27bffec0255a0eca4b762682dd4481
+generated: "2025-06-06T14:46:06.894674253-03:00"

--- a/charts/trustify-infrastructure/Chart.yaml
+++ b/charts/trustify-infrastructure/Chart.yaml
@@ -40,5 +40,5 @@ dependencies:
     condition: prometheus.enabled
   - name: opentelemetry-collector
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-    version: 0.111.1
+    version: 0.126.0
     condition: opentelemetry-collector.enabled

--- a/charts/trustify-infrastructure/values.yaml
+++ b/charts/trustify-infrastructure/values.yaml
@@ -19,7 +19,7 @@ prometheus:
 keycloakPostInstall:
   disabled: false
   # NOTE: this must be an image which contain things like bash, kcadm, grep, awk
-  image: docker.io/bitnami/keycloak:26.1.1-debian-12-r0
+  image: docker.io/bitnami/keycloak:26
   kcadmPath: /opt/bitnami/keycloak/bin/kcadm.sh
   realmAdmin:
     name: admin
@@ -40,12 +40,12 @@ env:
 opentelemetry-collector:
   enabled: false
   image:
-    repository: "otel/opentelemetry-collector-contrib"
+    repository: "otel/opentelemetry-collector"
   nameOverride: otelcol
+  command:
+    name: "otelcol"
   mode: deployment
   presets:
-    kubernetesAttributes:
-      enabled: true
     hostMetrics:
       enabled: false
   service:


### PR DESCRIPTION
Using the core (non contrib) OTELCOL `0.127.0` aligning with our [development environment](https://github.com/trustification/trustify/blob/main/etc/telemetry/compose.yaml#L37) 