### PR TITLE
chore: Enforce http/https prefix if required

### DIFF
--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -122,6 +122,7 @@
       "properties": {
         "endpoint": {
           "type": "string",
+          "pattern": "^(http|https)://",
           "description": "OpenTelemetry collector endpoint for tracing and metrics.\n"
         }
       }

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -122,6 +122,7 @@ properties:
     properties:
       endpoint:
         type: string
+        pattern: ^(http|https)://
         description: |
           OpenTelemetry collector endpoint for tracing and metrics.
 


### PR DESCRIPTION
```console
➜  trustify-helm-charts git:(issue-57) ✗ helm upgrade --install -n $NAMESPACE trustify charts/trustify --values values-minikube.yaml --set-string appDomain=$APP_DOMAIN --set tracing.enabled=true --set metrics.enabled=true --set-string collector.endpoint="infrastructure-otelcol:4317"
Release "trustify" does not exist. Installing it now.
Error: values don't meet the specifications of the schema(s) in the following chart(s):
trustify:
- collector.endpoint: Does not match pattern '^(http|https)://'

➜  trustify-helm-charts git:(issue-57) ✗ helm upgrade --install -n $NAMESPACE trustify charts/trustify --values values-minikube.yaml --set-string appDomain=$APP_DOMAIN --set tracing.enabled=true --set metrics.enabled=true --set-string collector.endpoint="http://infrastructure-otelcol:4317"
Release "trustify" does not exist. Installing it now.
NAME: trustify
LAST DEPLOYED: Wed Jul  2 07:33:16 2025
NAMESPACE: trustify
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
OpenShift:
  Detected:       false
  Use Service CA: false

Console:
    server.192.168.39.2.nip.io
```