### PR TITLE
chore: allow overriding some OTEL env vars via CLI

### DIFF
--- a/charts/trustify/templates/helpers/_infrastructure.tpl
+++ b/charts/trustify/templates/helpers/_infrastructure.tpl
@@ -38,17 +38,15 @@ Arguments (dict):
 {{- if eq ( include "trustification.application.metrics.enabled" .root ) "true" }}
 - name: METRICS
   value: "enabled"
+{{ include "trustification.application.metrics.otelMetricExportInterval" . }}
 {{- end }}
 
 {{- if eq ( include "trustification.application.tracing.enabled" .root ) "true" }}
 - name: TRACING
   value: "enabled"
-- name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
-  value: "32"
-- name: OTEL_TRACES_SAMPLER
-  value: parentbased_traceidratio
-- name: OTEL_TRACES_SAMPLER_ARG
-  value: "0.1"
+{{ include "trustification.application.tracing.otelBspMaxExportBatchSize" . }}
+{{ include "trustification.application.tracing.otelTracesSampler" . }}
+{{ include "trustification.application.tracing.otelTracesSamplerArg" . }}
 {{- end }}
 
 {{- if eq ( include "trustification.application.collector.enabled" .root ) "true" }}

--- a/charts/trustify/templates/helpers/_metrics.tpl
+++ b/charts/trustify/templates/helpers/_metrics.tpl
@@ -20,3 +20,16 @@ Arguments (dict):
 metrics: "true"
 {{ end }}
 {{- end }}
+
+{{/*
+Specifies how frequently metrics are exported by the application.
+
+Arguments (dict):
+  * .
+*/}}
+{{ define "trustification.application.metrics.otelMetricExportInterval"}}
+{{- if hasKey .root.Values.metrics "otelMetricExportInterval" }}
+- name: OTEL_METRIC_EXPORT_INTERVAL
+  value: {{ .root.Values.metrics.otelMetricExportInterval | quote }}
+{{ end }}
+{{- end }}

--- a/charts/trustify/templates/helpers/_tracing.tpl
+++ b/charts/trustify/templates/helpers/_tracing.tpl
@@ -7,3 +7,43 @@ Arguments (dict):
 {{ define "trustification.application.tracing.enabled"}}
 {{- .Values.tracing.enabled }}
 {{- end }}
+
+{{/*
+Maximum number of spans to export in a batch.
+
+Arguments (dict):
+  * .
+*/}}
+{{ define "trustification.application.tracing.otelBspMaxExportBatchSize"}}
+{{- if hasKey .root.Values.tracing "otelBspMaxExportBatchSize" }}
+- name: OTEL_BSP_MAX_EXPORT_BATCH_SIZE
+  value: {{ .root.Values.tracing.otelBspMaxExportBatchSize | quote }}
+{{ end }}
+{{- end }}
+
+{{/*
+Sampler strategy used for OpenTelemetry traces.
+
+Arguments (dict):
+  * .
+*/}}
+{{ define "trustification.application.tracing.otelTracesSampler"}}
+{{- if hasKey .root.Values.tracing "otelTracesSampler" }}
+- name: OTEL_TRACES_SAMPLER
+  value: {{ .root.Values.tracing.otelTracesSampler | quote }}
+{{ end }}
+{{- end }}
+
+{{/*
+Sampling probability, a floating-point number between 0 and 1
+(e.g., "0.1" for a 10% sampling rate)
+
+Arguments (dict):
+  * .
+*/}}
+{{ define "trustification.application.tracing.otelTracesSamplerArg"}}
+{{- if hasKey .root.Values.tracing "otelTracesSamplerArg" }}
+- name: OTEL_TRACES_SAMPLER_ARG
+  value: {{ .root.Values.tracing.otelTracesSamplerArg | quote }}
+{{ end }}
+{{- end }}

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -103,6 +103,10 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable support for application metrics.\n"
+        },
+        "otelMetricExportInterval": {
+          "type": "integer",
+          "description": "The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.\n"
         }
       }
     },
@@ -113,6 +117,19 @@
         "enabled": {
           "type": "boolean",
           "description": "Enable support for distributed tracing.\n"
+        },
+        "otelBspMaxExportBatchSize": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.\n"
+        },
+        "otelTracesSampler": {
+          "type": "string",
+          "description": "The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.\n"
+        },
+        "otelTracesSamplerArg": {
+          "type": "string",
+          "description": "The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.\n"
         }
       }
     },
@@ -475,6 +492,10 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "otelMetricExportInterval": {
+          "type": "integer",
+          "description": "The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.\n"
         }
       }
     },
@@ -495,6 +516,19 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "otelBspMaxExportBatchSize": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.\n"
+        },
+        "otelTracesSampler": {
+          "type": "string",
+          "description": "The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.\n"
+        },
+        "otelTracesSamplerArg": {
+          "type": "string",
+          "description": "The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.\n"
         }
       }
     },

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -106,6 +106,10 @@ properties:
         type: boolean
         description: |
           Enable support for application metrics.
+      otelMetricExportInterval:
+        type: integer
+        description: |
+          The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.
 
   tracing:
     type: object
@@ -115,6 +119,19 @@ properties:
         type: boolean
         description: |
           Enable support for distributed tracing.
+      otelBspMaxExportBatchSize:
+        type: integer
+        minimum: 1
+        description: |
+          The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.
+      otelTracesSampler:
+        type: string
+        description: |
+          The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.
+      otelTracesSamplerArg:
+        type: string
+        description: |
+          The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.
 
   collector:
     type: object
@@ -354,6 +371,10 @@ definitions:
     properties:
       enabled:
         type: boolean
+      otelMetricExportInterval:
+        type: integer
+        description: |
+          The interval in milliseconds for exporting metrics. Will be used as the value for the `OTEL_METRIC_EXPORT_INTERVAL` variable.
 
   Tracing:
     type: object
@@ -369,6 +390,19 @@ definitions:
     properties:
       enabled:
         type: boolean
+      otelBspMaxExportBatchSize:
+        type: integer
+        minimum: 1
+        description: |
+          The maximum batch size for exporting spans. Will be used as the value for the `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` variable.
+      otelTracesSampler:
+        type: string
+        description: |
+          The trace sampling strategy. Will be used as the value for the `OTEL_TRACES_SAMPLER` variable.
+      otelTracesSamplerArg:
+        type: string
+        description: |
+          The trace sampling probability. Will be used as the value for the `OTEL_TRACES_SAMPLER_ARG` variable.
 
   Image:
     type: object


### PR DESCRIPTION
<img width="1920" height="487" alt="2025-08-01_10-59" src="https://github.com/user-attachments/assets/9f03e546-7563-4fab-aeed-ac783e8eb667" />

## Summary by Sourcery

Allow overriding OpenTelemetry environment variables via Helm chart CLI by introducing new configuration values for metrics export interval and tracing parameters, and updating the chart templates and schemas to support these overrides

New Features:
- Add Helm value `otelMetricExportInterval` to customize OTEL_METRIC_EXPORT_INTERVAL for metrics export
- Add Helm values `otelBspMaxExportBatchSize`, `otelTracesSampler`, and `otelTracesSamplerArg` to customize OTEL_BSP_MAX_EXPORT_BATCH_SIZE, OTEL_TRACES_SAMPLER, and OTEL_TRACES_SAMPLER_ARG for tracing

Enhancements:
- Update Helm chart templates to conditionally inject new OTEL environment variables when the corresponding values are set
- Extend values schema (YAML and JSON) with descriptions and validation for the new OTEL configuration options