### PR TITLE
chore: rename default OIDC realm with trustify

### DIFF
--- a/charts/trustify-infrastructure/Chart.yaml
+++ b/charts/trustify-infrastructure/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
     email: jreimann@redhat.com
 
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"
 icon: https://raw.githubusercontent.com/trustification/trustification/main/docs/branding/svg/trustification_icon_default.svg
 home: https://trustification.io

--- a/charts/trustify-infrastructure/templates/keycloak/010-ConfigMap.yaml
+++ b/charts/trustify-infrastructure/templates/keycloak/010-ConfigMap.yaml
@@ -169,7 +169,7 @@ data:
     else
       kcadm create clients -r "${REALM}" -f "${INIT_DATA}/client-testing-manager.json" "${CLIENT_OPTS[@]}"
     fi
-    kcadm add-roles -r "${REALM}" --uusername service-account-{{ .Values.oidc.clients.testingManager.clientId | default "testing-manager" | quote }} --rolename chicken-manager
+    kcadm add-roles -r "${REALM}" --uusername service-account-{{ .Values.oidc.clients.testingManager.clientId | default "testing-manager" | quote }} --rolename trustify-manager
     # now set the client-secret
     ID=$(kcadm get clients -r "${REALM}" --query "clientId="{{ .Values.oidc.clients.testingManager.clientId | default "testing-manager" | quote }} --fields id --format csv --noquotes)
     kcadm update "clients/${ID}" -r "${REALM}" -s "secret=${TESTING_MANAGER_SECRET}"
@@ -189,7 +189,7 @@ data:
     else
       kcadm create clients -r "${REALM}" -f "${INIT_DATA}/client-testing-user.json" "${CLIENT_OPTS[@]}"
     fi
-    kcadm add-roles -r "${REALM}" --uusername service-account-{{ .Values.oidc.clients.testingUser.clientId | default "testing-user" | quote }} --rolename chicken-manager
+    kcadm add-roles -r "${REALM}" --uusername service-account-{{ .Values.oidc.clients.testingUser.clientId | default "testing-user" | quote }} --rolename trustify-manager
     # now set the client-secret
     ID=$(kcadm get clients -r "${REALM}" --query "clientId="{{ .Values.oidc.clients.testingUser.clientId | default "testing-user" | quote }} --fields id --format csv --noquotes)
     kcadm update "clients/${ID}" -r "${REALM}" -s "secret=${TESTING_USER_SECRET}"

--- a/charts/trustify-infrastructure/templates/keycloak/020-Job.yaml
+++ b/charts/trustify-infrastructure/templates/keycloak/020-Job.yaml
@@ -52,11 +52,11 @@ spec:
               value: /etc/init-data
 
             - name: REALM
-              value: {{ .Values.keycloakPostInstall.realm | default "chicken" }}
+              value: {{ .Values.keycloakPostInstall.realm | default "trustify" }}
 
-            - name: CHICKEN_ADMIN
+            - name: TRUSTIFY_ADMIN
               value: {{ .Values.keycloakPostInstall.realmAdmin.name | default "admin" }}
-            - name: CHICKEN_ADMIN_PASSWORD
+            - name: TRUSTIFY_ADMIN_PASSWORD
               value: {{ .Values.keycloakPostInstall.realmAdmin.password | quote }}
 
             - name: REDIRECT_URIS
@@ -147,13 +147,13 @@ spec:
               fi
 
               # create realm roles
-              kcadm create roles -r "${REALM}" -s name=chicken-user || true
-              kcadm create roles -r "${REALM}" -s name=chicken-manager || true
-              kcadm create roles -r "${REALM}" -s name=chicken-admin || true
-              # add chicken-user as default role
-              kcadm add-roles -r "${REALM}" --rname "default-roles-${REALM}" --rolename chicken-user
+              kcadm create roles -r "${REALM}" -s name=trustify-user || true
+              kcadm create roles -r "${REALM}" -s name=trustify-manager || true
+              kcadm create roles -r "${REALM}" -s name=trustify-admin || true
+              # add trustify-user as default role
+              kcadm add-roles -r "${REALM}" --rname "default-roles-${REALM}" --rolename trustify-user
 
-              MANAGER_ID=$(kcadm get roles -r "${REALM}" --fields id,name --format csv --noquotes | grep ",chicken-manager" | awk -F ',' '{print $1}')
+              MANAGER_ID=$(kcadm get roles -r "${REALM}" --fields id,name --format csv --noquotes | grep ",trustify-manager" | awk -F ',' '{print $1}')
 
               # create scopes
               # shellcheck disable=SC2043
@@ -164,8 +164,8 @@ spec:
               for i in create:document update:document delete:document; do
                 kcadm create client-scopes -r "${REALM}" -s "name=$i" -s protocol=openid-connect || true
                 ID=$(kcadm get client-scopes -r "${REALM}" --fields id,name --format csv --noquotes | grep ",${i}" | awk -F ',' '{print $1}')
-                # add all scopes to the chicken-manager
-                kcadm create "client-scopes/${ID}/scope-mappings/realm" -r "${REALM}" -b '[{"name":"chicken-manager", "id":"'"${MANAGER_ID}"'"}]' || true
+                # add all scopes to the trustify-manager
+                kcadm create "client-scopes/${ID}/scope-mappings/realm" -r "${REALM}" -b '[{"name":"trustify-manager", "id":"'"${MANAGER_ID}"'"}]' || true
               done
 
               {{ if hasKey .Values.oidc.clients "frontend" }}
@@ -202,35 +202,35 @@ spec:
                   # now set the client-secret
                   ID=$(kcadm get clients -r "${REALM}" --query exact=true --query "clientId=${client}" --fields id --format csv --noquotes)
                   if [ "${client}" == "cli" ]; then
-                      kcadm add-roles -r "${REALM}" --uusername service-account-${client} --rolename chicken-manager
+                      kcadm add-roles -r "${REALM}" --uusername service-account-${client} --rolename trustify-manager
                       kcadm update "clients/${ID}" -r "${REALM}" -s "secret=${CLI_SECRET}"
                   fi
                   if [ "${client}" == "testing-manager" ]; then
-                      kcadm add-roles -r "${REALM}" --uusername service-account-${client} --rolename chicken-manager
+                      kcadm add-roles -r "${REALM}" --uusername service-account-${client} --rolename trustify-manager
                       kcadm update "clients/${ID}" -r "${REALM}" -s "secret=${TESTING_MANAGER_SECRET}"
                   fi
                   if [ "${client}" == "testing-user" ]; then
-                      kcadm add-roles -r "${REALM}" --uusername service-account-${client} --rolename chicken-user
+                      kcadm add-roles -r "${REALM}" --uusername service-account-${client} --rolename trustify-user
                       kcadm update "clients/${ID}" -r "${REALM}" -s "secret=${TESTING_USER_SECRET}"
                   fi
               done
 
               # create user
-              ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${CHICKEN_ADMIN}" --fields id --format csv --noquotes)
+              ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${TRUSTIFY_ADMIN}" --fields id --format csv --noquotes)
               # the next check might seem weird, but that's just Keycloak reporting a "user not found" in two different ways
               if [[ -n "$ID" || "$ID" == "[]" ]]; then
                 kcadm update "users/$ID" -r "${REALM}" -s enabled=true
               else
-                kcadm create users -r "${REALM}" -s "username=${CHICKEN_ADMIN}" -s enabled=true -s email=test@example.com -s emailVerified=true -s firstName=Admin -s lastName=Admin
+                kcadm create users -r "${REALM}" -s "username=${TRUSTIFY_ADMIN}" -s enabled=true -s email=test@example.com -s emailVerified=true -s firstName=Admin -s lastName=Admin
               fi
 
               # set role
-              kcadm add-roles -r "${REALM}" --uusername "${CHICKEN_ADMIN}" --rolename chicken-admin
-              kcadm add-roles -r "${REALM}" --uusername "${CHICKEN_ADMIN}" --rolename chicken-manager
+              kcadm add-roles -r "${REALM}" --uusername "${TRUSTIFY_ADMIN}" --rolename trustify-admin
+              kcadm add-roles -r "${REALM}" --uusername "${TRUSTIFY_ADMIN}" --rolename trustify-manager
 
               # set password
-              ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${CHICKEN_ADMIN}" --fields id --format csv --noquotes)
-              kcadm update "users/${ID}/reset-password" -r "${REALM}" -s type=password -s "value=${CHICKEN_ADMIN_PASSWORD}" -s temporary=false -n
+              ID=$(kcadm get users -r "${REALM}" --query exact=true --query "username=${TRUSTIFY_ADMIN}" --fields id --format csv --noquotes)
+              kcadm update "users/${ID}/reset-password" -r "${REALM}" -s type=password -s "value=${TRUSTIFY_ADMIN_PASSWORD}" -s temporary=false -n
 
               if [[ -f "${INIT_DATA}/there-is-more.sh" ]]; then
                 echo Performing additional setup

--- a/charts/trustify/Chart.yaml
+++ b/charts/trustify/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
     email: jreimann@redhat.com
 
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "0.3.5"
 icon: https://raw.githubusercontent.com/trustification/trustification/main/docs/branding/svg/trustification_icon_default.svg
 home: https://trustification.io

--- a/charts/trustify/templates/helpers/_oidc.tpl
+++ b/charts/trustify/templates/helpers/_oidc.tpl
@@ -73,7 +73,7 @@ Arguments (dict):
 {{- else if .root.Values.oidc.issuerUrl }}
 {{- .root.Values.oidc.issuerUrl }}
 {{- else -}}
-{{ include "trustification.tls.http.protocol" . }}://sso{{ .root.Values.appDomain }}/realms/chicken
+{{ include "trustification.tls.http.protocol" . }}://sso{{ .root.Values.appDomain }}/realms/trustify
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary by Sourcery

Perform a global rename of the default Keycloak realm from “chicken” to “trustify,” update all related environment variables, roles, client-scopes, user assignments, and adjust the OIDC issuer URL accordingly; bump the corresponding Helm chart versions.

Enhancements:
- Rename Keycloak realm default from "chicken" to "trustify" and update related environment variables
- Update Keycloak initialization scripts to remap roles, client scopes, and service-account role assignments for the new realm identifier
- Adjust OIDC helper template to reference the trustify realm path

Build:
- Bump charts/trustify-infrastructure to version 0.1.4
- Bump charts/trustify to version 0.2.5