### PR TITLE
Update system information client scope to Auth template

### DIFF
--- a/charts/trustify/templates/helpers/_auth.tpl
+++ b/charts/trustify/templates/helpers/_auth.tpl
@@ -152,6 +152,7 @@ authentication:
           - "read.metadata"
           - "update.metadata"
           - "delete.metadata"
+          - "read.systemInformation"
         "trustify/sbom":
           - "create.sbom"
           - "read.sbom"
@@ -172,7 +173,7 @@ authentication:
       issuerUrl: {{ include "trustification.oidc.issuerUrlForClient" (dict "root" .root "clientId" "frontend" ) }}
       scopeMappings: &keycloakScopeMappings
         "create:document": [ "create.advisory", "create.importer", "create.metadata", "create.sbom", "create.weakness", "upload.dataset" ]
-        "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.weakness" ]
+        "read:document": [ "ai", "read.advisory", "read.importer", "read.metadata", "read.sbom", "read.weakness", "read.systemInformation" ]
         "update:document": [ "update.advisory", "update.importer", "update.metadata", "update.sbom", "update.weakness" ]
         "delete:document": [ "delete.advisory", "delete.importer", "delete.metadata", "delete.sbom", "delete.vulnerability", "delete.weakness" ]
       {{- with .root.Values.tls.additionalTrustAnchor }}


### PR DESCRIPTION
Updating helm chart for the change in https://github.com/guacsec/trustify/pull/2058/files 
JIRA - https://issues.redhat.com/browse/TC-2550
Screenshots for reference:
Openshift updated with clientScope without issue
<img width="1863" height="521" alt="image" src="https://github.com/user-attachments/assets/632afd92-4527-48fd-b506-e6c2be47ec08" />

TPA API request returns without 403:
<img width="1519" height="836" alt="image" src="https://github.com/user-attachments/assets/2cd12b7b-d2cd-4601-814a-70c0f8dc6922" />

## Summary by Sourcery

Update Helm chart authentication template to grant systemInformation read access by adding the new scope to the systemInformation client and frontend mappings

Enhancements:
- Add "read.systemInformation" permission to the systemInformation client scope
- Include "read.systemInformation" in the frontend’s "read:document" scope mapping