### PR TITLE
Add UI_SCOPE to handle OIDC custom scope

### DIFF
--- a/charts/trustify/templates/helpers/_oidc.tpl
+++ b/charts/trustify/templates/helpers/_oidc.tpl
@@ -25,6 +25,16 @@ Arguments: (dict)
 {{- end }}
 
 {{/*
+UI scopes passed to the backend for the frontend client.
+Arguments: .
+*/}}
+{{- define "trustification.oidc.uiScopes" -}}
+{{- if .Values.oidc.uiScopes -}}
+{{- .Values.oidc.uiScopes -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Configuration required for setting up an OIDC client for making requests
 
 Arguments (dict):

--- a/charts/trustify/templates/services/server/030-Deployment.yaml
+++ b/charts/trustify/templates/services/server/030-Deployment.yaml
@@ -57,6 +57,10 @@ spec:
               value: {{ include "trustification.oidc.frontendIssuerUrl" . }}
             - name: UI_CLIENT_ID
               value: {{ include "trustification.oidc.frontendClientId" . }}
+            {{- with (include "trustification.oidc.uiScopes" . | trim) }}
+            - name: UI_SCOPES
+              value: {{ . | quote }}
+            {{- end }}
 
             {{- with $mod.module.uploadLimit }}
             - name: TRUSTD_SBOM_UPLOAD_LIMIT

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -742,6 +742,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "uiScopes": {
+          "type": "string",
+          "description": "Optional value for the `UI_SCOPES` environment variable in the server deployment.\n"
+        },
         "issuerUrl": {
           "$ref": "#/definitions/ValueOrRef"
         },

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -568,6 +568,11 @@ definitions:
     type: object
     additionalProperties: false
     properties:
+      uiScopes:
+        type: string
+        description: |
+          Optional value for the `UI_SCOPES` environment variable in the server deployment.
+
       issuerUrl:
         $ref: "#/definitions/ValueOrRef"
 

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -22,6 +22,7 @@ openshift:
   useServiceCa: true
 
 oidc:
+  uiScopes: ""
   clients:
     frontend: {}
     cli:


### PR DESCRIPTION
Adding UI_SCOPE to helm chart to handle OIDC custom scope values.

## Summary by Sourcery

New Features:
- Allow configuring a UI-specific OIDC scope through the Helm chart using the new `oidc.uiScopes` value.