### PR TITLE
feat: allow setting pagination cache ttl

### DIFF
--- a/charts/trustify/templates/services/server/030-Deployment.yaml
+++ b/charts/trustify/templates/services/server/030-Deployment.yaml
@@ -76,6 +76,11 @@ spec:
               value: {{ . | quote }}
             {{- end }}
 
+            {{- with $mod.module.paginationCacheTtl }}
+            - name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL
+              value: {{ . | quote }}
+            {{- end }}
+
             {{- if eq ( include "trustification.openshift.useServiceCa" .root ) "true" }}
             - name: CLIENT_TLS_CA_CERTIFICATES
               value: /run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -238,6 +238,10 @@
                 "maximumCacheSize": {
                   "description": "The maximum number of the bytes the analysis cache will hold before evicting entries.\n",
                   "$ref": "#/definitions/ByteSize"
+                },
+                "paginationCacheTtl": {
+                  "type": "string",
+                  "description": "The TTL for the pagination total-count cache (humantime, e.g. \"60s\", \"5m\").\nIf not set, the application default of \"60s\" is used.\n"
                 }
               }
             }

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -230,6 +230,7 @@ properties:
                 description: |
                   Enable read-only mode. When true, the server rejects all mutating API
                   requests with 503 and the importer suspends all import jobs.
+                  
       importer:
         description: |
           The main server process.

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -230,7 +230,7 @@ properties:
                 description: |
                   Enable read-only mode. When true, the server rejects all mutating API
                   requests with 503 and the importer suspends all import jobs.
-                  
+      
       importer:
         description: |
           The main server process.

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -208,6 +208,11 @@ properties:
                 description: |
                   The maximum number of the bytes the analysis cache will hold before evicting entries.
                 $ref: "#/definitions/ByteSize"
+              paginationCacheTtl:
+                type: string
+                description: |
+                  The TTL for the pagination total-count cache (humantime, e.g. "60s", "5m").
+                  If not set, the application default of "60s" is used.
 
       importer:
         description: |


### PR DESCRIPTION
## Summary by Sourcery

Add configurable TTL support for the pagination total-count cache in the server Helm chart.

New Features:
- Introduce a paginationCacheTtl Helm value to control the TTL of the pagination total-count cache for the server component.

Documentation:
- Document the new paginationCacheTtl Helm value and its default behavior in the values schema.