### PR TITLE
feat: pass in storage configuration to migration

### DIFF
--- a/charts/trustify/templates/init/migrate-database/020-Job.yaml
+++ b/charts/trustify/templates/init/migrate-database/020-Job.yaml
@@ -34,6 +34,7 @@ spec:
       {{- include "trustification.application.pod" $mod | nindent 6 }}
 
       volumes:
+        {{- include "trustification.storage.volume" $mod | nindent 8 }}
         {{- include "trustification.application.extraVolumes" $mod | nindent 8 }}
 
       containers:
@@ -43,8 +44,10 @@ spec:
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}
+            {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 
           volumeMounts:
+            {{- include "trustification.storage.volumeMount" $mod | nindent 12 }}
             {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}
 
           command:


### PR DESCRIPTION
This is required by 0.5.0 onwards for re-ingesting documents.

## Summary by Sourcery

Configure the database migration job to receive storage settings required for document re-ingestion.

New Features:
- Inject storage-related environment variables into the database migration job container.
- Attach storage volumes and corresponding mounts to the database migration job pod.