### PR TITLE
Enable storage to be create before migratedb

### DIFF
--- a/charts/trustify/templates/common/010-PersistentVolumeClaim-storage.yaml
+++ b/charts/trustify/templates/common/010-PersistentVolumeClaim-storage.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.modules.server.enabled }}
 {{- $res := dict "root" . "name" "storage" -}}
 
 {{- if eq .Values.storage.type "filesystem" }}
@@ -8,6 +7,10 @@ metadata:
   name: {{ include "trustification.common.name" $res }}
   labels:
     {{- include "trustification.common.labels" $res | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-weight: "10"
+    helm.sh/resource-policy: keep
 
 spec:
   accessModes:
@@ -18,8 +21,6 @@ spec:
 
 {{- with .Values.storage.storageClassName }}
   storageClassName: {{ . | quote }}
-{{- end }}
-
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## Summary by Sourcery

Create the shared filesystem storage PersistentVolumeClaim as a common Helm template with pre-install and pre-upgrade hooks so it is provisioned before dependent components.

Enhancements:
- Move the storage PersistentVolumeClaim definition from the server-specific templates to a shared common template so it can be reused by multiple modules.
- Ensure the filesystem storage PersistentVolumeClaim is created via Helm pre-install and pre-upgrade hooks and retained across releases.