### PR TITLE
Storage created before migratedb and server start

### DIFF
--- a/charts/trustify/templates/common/010-PersistentVolumeClaim-storage.yaml
+++ b/charts/trustify/templates/common/010-PersistentVolumeClaim-storage.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.modules.server.enabled }}
 {{- $res := dict "root" . "name" "storage" -}}
 
 {{- if eq .Values.storage.type "filesystem" }}
@@ -9,6 +8,11 @@ metadata:
   labels:
     {{- include "trustification.common.labels" $res | nindent 4 }}
 
+  annotations:
+    helm.sh/hook: "pre-install,pre-upgrade"
+    helm.sh/hook-weight: "10"
+    helm.sh/resource-policy: keep
+
 spec:
   accessModes:
     - ReadWriteOnce
@@ -18,8 +22,6 @@ spec:
 
 {{- with .Values.storage.storageClassName }}
   storageClassName: {{ . | quote }}
-{{- end }}
-
 {{- end }}
 
 {{- end }}

--- a/charts/trustify/templates/common/010-PersistentVolumeClaim-storage.yaml
+++ b/charts/trustify/templates/common/010-PersistentVolumeClaim-storage.yaml
@@ -1,6 +1,9 @@
 {{- $res := dict "root" . "name" "storage" -}}
 
 {{- if eq .Values.storage.type "filesystem" }}
+{{- $pvcName := (include "trustification.common.name" $res) }}
+{{- $existingPVC := (lookup "v1" "PersistentVolumeClaim" .Release.Namespace $pvcName) }}
+{{- if not $existingPVC }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -24,4 +27,5 @@ spec:
   storageClassName: {{ . | quote }}
 {{- end }}
 
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Move the storage PersistentVolumeClaim template to a common location and add lookup logic to skip creating the PVC when it already exists.