### PR TITLE
feat: allow setting the read-only flag

### DIFF
--- a/charts/trustify/templates/helpers/_readOnly.tpl
+++ b/charts/trustify/templates/helpers/_readOnly.tpl
@@ -1,0 +1,20 @@
+{{/*
+Resolve the effective read-only flag: module-level overrides the global default.
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.application.readOnly.envVars" }}
+{{- if hasKey .module "readOnly" -}}
+{{- with .module.readOnly }}
+- name: TRUSTD_READ_ONLY
+  value: {{ . | quote }}
+{{- end }}
+{{- else -}}
+{{- with .root.Values.readOnly }}
+- name: TRUSTD_READ_ONLY
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/trustify/templates/services/importer/030-Deployment.yaml
+++ b/charts/trustify/templates/services/importer/030-Deployment.yaml
@@ -47,6 +47,7 @@ spec:
 
             {{- include "trustification.application.rust.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 

--- a/charts/trustify/templates/services/server/030-Deployment.yaml
+++ b/charts/trustify/templates/services/server/030-Deployment.yaml
@@ -49,6 +49,7 @@ spec:
             {{- include "trustification.application.rust.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.infrastructure.envVars" $mod | nindent 12 }}
             {{- include "trustification.application.httpServer.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
             {{- include "trustification.oidc.swaggerUi" $mod | nindent 12 }}

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -64,6 +64,11 @@
     "oidc": {
       "$ref": "#/definitions/Oidc"
     },
+    "readOnly": {
+      "type": "boolean",
+      "default": false,
+      "description": "Global default for read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\nCan be overridden per module via modules.server.readOnly / modules.importer.readOnly.\n"
+    },
     "replicas": {
       "type": "integer",
       "minimum": 0,
@@ -238,6 +243,10 @@
                 "maximumCacheSize": {
                   "description": "The maximum number of the bytes the analysis cache will hold before evicting entries.\n",
                   "$ref": "#/definitions/ByteSize"
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"
                 }
               }
             }
@@ -291,6 +300,10 @@
                 },
                 "storageClassName": {
                   "type": "string"
+                },
+                "readOnly": {
+                  "type": "boolean",
+                  "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"
                 }
               }
             }

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -67,6 +67,14 @@ properties:
   oidc:
     $ref: "#/definitions/Oidc"
 
+  readOnly:
+    type: boolean
+    default: false
+    description: |
+      Global default for read-only mode. When true, the server rejects all mutating API
+      requests with 503 and the importer suspends all import jobs.
+      Can be overridden per module via modules.server.readOnly / modules.importer.readOnly.
+
   replicas:
     type: integer
     minimum: 0
@@ -208,6 +216,11 @@ properties:
                 description: |
                   The maximum number of the bytes the analysis cache will hold before evicting entries.
                 $ref: "#/definitions/ByteSize"
+              readOnly:
+                type: boolean
+                description: |
+                  Enable read-only mode. When true, the server rejects all mutating API
+                  requests with 503 and the importer suspends all import jobs.
 
       importer:
         description: |
@@ -237,6 +250,11 @@ properties:
                   The max number of import jobs that may run concurrently
               storageClassName:
                 type: string
+              readOnly:
+                type: boolean
+                description: |
+                  Enable read-only mode. When true, the server rejects all mutating API
+                  requests with 503 and the importer suspends all import jobs.
 
       createDatabase:
         description: |

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -9,6 +9,8 @@ image:
 
 rust: {}
 
+readOnly: false
+
 ingress:
   enabled: true
 
@@ -65,6 +67,7 @@ modules:
         cpu: 1
         memory: 8Gi
     concurrency: 1
+    # readOnly: false
     workingDirectory:
       size: 32Gi
 


### PR DESCRIPTION
Note: this is also required for the 0.4.x (2.2.x) charts.