### PR TITLE
feat: rename uiScopes to uiScope and add loadUser OIDC option

### DIFF
--- a/charts/trustify/templates/helpers/_oidc.tpl
+++ b/charts/trustify/templates/helpers/_oidc.tpl
@@ -28,10 +28,18 @@ Arguments: (dict)
 UI scopes passed to the backend for the frontend client.
 Arguments: .
 */}}
-{{- define "trustification.oidc.uiScopes" -}}
-{{- if .Values.oidc.uiScopes -}}
-{{- .Values.oidc.uiScopes -}}
+{{- define "trustification.oidc.uiScope" -}}
+{{- if .Values.oidc.uiScope -}}
+{{- .Values.oidc.uiScope -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+OIDC user Info boolean.
+Arguments: .
+*/}}
+{{- define "trustification.oidc.loadUser" -}}
+{{- .Values.oidc.loadUser | quote -}}
 {{- end -}}
 
 {{/*

--- a/charts/trustify/templates/services/server/030-Deployment.yaml
+++ b/charts/trustify/templates/services/server/030-Deployment.yaml
@@ -58,8 +58,10 @@ spec:
               value: {{ include "trustification.oidc.frontendIssuerUrl" . }}
             - name: UI_CLIENT_ID
               value: {{ include "trustification.oidc.frontendClientId" . }}
-            {{- with (include "trustification.oidc.uiScopes" . | trim) }}
-            - name: UI_SCOPES
+            - name: UI_LOAD_USER
+              value: {{ include "trustification.oidc.loadUser" . }}
+            {{- with (include "trustification.oidc.uiScope" . | trim) }}
+            - name: UI_SCOPE
               value: {{ . | quote }}
             {{- end }}
 

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -762,9 +762,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "uiScopes": {
+        "uiScope": {
           "type": "string",
-          "description": "Optional value for the `UI_SCOPES` environment variable in the server deployment.\n"
+          "description": "Optional value for the `UI_SCOPE` environment variable in the server deployment.\n"
         },
         "issuerUrl": {
           "$ref": "#/definitions/ValueOrRef"
@@ -773,6 +773,11 @@
           "type": "boolean",
           "description": "Use insecure TLS when communicating with the issuer (DANGER!)\n",
           "default": false
+        },
+        "loadUser": {
+          "type": "boolean",
+          "description": "Value for the `UI_LOAD_USER` environment variable in the server deployment\n",
+          "default": true
         },
         "clients": {
           "properties": {

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -592,10 +592,10 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      uiScopes:
+      uiScope:
         type: string
         description: |
-          Optional value for the `UI_SCOPES` environment variable in the server deployment.
+          Optional value for the `UI_SCOPE` environment variable in the server deployment.
 
       issuerUrl:
         $ref: "#/definitions/ValueOrRef"
@@ -605,6 +605,12 @@ definitions:
         description: |
           Use insecure TLS when communicating with the issuer (DANGER!)
         default: false
+
+      loadUser:
+        type: boolean
+        description: |
+          Value for the `UI_LOAD_USER` environment variable in the server deployment
+        default: true
 
       clients:
         properties:

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -24,7 +24,8 @@ openshift:
   useServiceCa: true
 
 oidc:
-  uiScopes: ""
+  uiScope: ""
+  loadUser: true
   clients:
     frontend: {}
     cli:


### PR DESCRIPTION
Added `loadUser` and updated `uiScope`

## Summary by Sourcery

Rename the OIDC UI scopes configuration to a singular UI scope and introduce a configurable option to control loading of the OIDC user in the server deployment.

New Features:
- Add a configurable `loadUser` OIDC option wired through to the `UI_LOAD_USER` environment variable.

Enhancements:
- Rename the `uiScopes` Helm value and helper to `uiScope` and update server deployment to use the `UI_SCOPE` environment variable instead of `UI_SCOPES`.