### PR TITLE
feat: add data migration skip options to migrateDatabase job

### DIFF
--- a/charts/trustify/templates/init/migrate-database/020-Job.yaml
+++ b/charts/trustify/templates/init/migrate-database/020-Job.yaml
@@ -46,6 +46,18 @@ spec:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
 
+            {{- if and .Values.modules.migrateDatabase.dataMigrationSkip .Values.modules.migrateDatabase.dataMigrationSkipAll }}
+            {{- fail "dataMigrationSkip and dataMigrationSkipAll are mutually exclusive" }}
+            {{- end }}
+            {{- with .Values.modules.migrateDatabase.dataMigrationSkip }}
+            - name: MIGRATION_DATA_SKIP
+              value: {{ join "," . | quote }}
+            {{- end }}
+            {{- if .Values.modules.migrateDatabase.dataMigrationSkipAll }}
+            - name: MIGRATION_DATA_SKIP_ALL
+              value: "true"
+            {{- end }}
+
           volumeMounts:
             {{- include "trustification.storage.volumeMount" $mod | nindent 12 }}
             {{- include "trustification.application.extraVolumeMounts" $mod | nindent 12 }}

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -334,6 +334,23 @@
             },
             {
               "$ref": "#/definitions/Application"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "dataMigrationSkip": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "List of data migration names to skip during the migration job.\nSets the `MIGRATION_DATA_SKIP` environment variable.\n"
+                },
+                "dataMigrationSkipAll": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Skip all data migrations. Sets the `MIGRATION_DATA_SKIP_ALL` environment variable.\nConflicts with `dataMigrationSkip`.\n"
+                }
+              }
             }
           ]
         },

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -271,6 +271,21 @@ properties:
           - $ref: "#/definitions/Feature"
           - $ref: "#/definitions/Image"
           - $ref: "#/definitions/Application"
+          - type: object
+            properties:
+              dataMigrationSkip:
+                type: array
+                items:
+                  type: string
+                description: |
+                  List of data migration names to skip during the migration job.
+                  Sets the `MIGRATION_DATA_SKIP` environment variable.
+              dataMigrationSkipAll:
+                type: boolean
+                default: false
+                description: |
+                  Skip all data migrations. Sets the `MIGRATION_DATA_SKIP_ALL` environment variable.
+                  Conflicts with `dataMigrationSkip`.
 
       createImporters:
         description: |

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -82,6 +82,9 @@ modules:
   migrateDatabase:
     enabled: false
     image: {}
+    # dataMigrationSkip:
+    #   - m0002000_add_sbom_properties
+    # dataMigrationSkipAll: false
 
   createImporters:
     enabled: false


### PR DESCRIPTION
## Summary

* Add `dataMigrationSkip` (list of migration names) and `dataMigrationSkipAll` (boolean) values to the `migrateDatabase` module
* These set the `MIGRATION_DATA_SKIP` and `MIGRATION_DATA_SKIP_ALL` environment variables on the migration job
* Useful when data migrations have been run separately (e.g. via the concurrent data migration procedure from guacsec/trustify#2421)

## Example usage

```yaml
modules:
  migrateDatabase:
    enabled: true
    dataMigrationSkip:
      - m0002000_add_sbom_properties
      - m0002010_add_advisory_scores
```

or to skip all data migrations:

```yaml
modules:
  migrateDatabase:
    enabled: true
    dataMigrationSkipAll: true
```

## Test plan

- [x] `helm template` with `dataMigrationSkip` list renders `MIGRATION_DATA_SKIP` with comma-separated values
- [x] `helm template` with `dataMigrationSkipAll: true` renders `MIGRATION_DATA_SKIP_ALL=true`
- [x] `helm template` without either option renders no `MIGRATION_DATA_*` env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configuration options to control skipping data migrations in the migrateDatabase Helm module.

New Features:
- Introduce dataMigrationSkip and dataMigrationSkipAll options for the migrateDatabase module to selectively skip data migrations.

Enhancements:
- Expose MIGRATION_DATA_SKIP and MIGRATION_DATA_SKIP_ALL environment variables in the migrate-database job based on module configuration.
- Document example usage of dataMigrationSkip and dataMigrationSkipAll in values.yaml for Helm users.