### PR TITLE
fix: correct nindent value for application.container in Job templates

### DIFF
--- a/charts/trustify/templates/init/create-database/020-Job.yaml
+++ b/charts/trustify/templates/init/create-database/020-Job.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
         - name: job
           {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
-          {{- include "trustification.application.container" $mod | nindent 6 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
 
           env:
             # connect using the `createDatabase` settings

--- a/charts/trustify/templates/init/create-importers/020-Job.yaml
+++ b/charts/trustify/templates/init/create-importers/020-Job.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
         - name: job
           {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
-          {{- include "trustification.application.container" $mod | nindent 6 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
 
           env:
             {{- include "trustification.psql.envVars" ( dict "root" . "database" ( merge ( deepCopy (.Values.modules.createImporters.database | default dict ) ) (deepCopy .Values.database) ) ) | nindent 12 }}

--- a/charts/trustify/templates/init/migrate-database/020-Job.yaml
+++ b/charts/trustify/templates/init/migrate-database/020-Job.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
         - name: job
           {{- include "trustification.common.defaultImage" $mod | nindent 10 }}
-          {{- include "trustification.application.container" $mod | nindent 6 }}
+          {{- include "trustification.application.container" $mod | nindent 10 }}
 
           env:
             {{- include "trustification.postgres.envVars" ( dict "root" . "database" ( merge ( required "Using migrateDatabase requires setting .Values.migrateDatabase" (deepCopy .Values.migrateDatabase) ) ( deepCopy .Values.database ) ) ) | nindent 12 }}


### PR DESCRIPTION
## Summary

- Fix incorrect `nindent 6` → `nindent 10` for `trustification.application.container` helper in all three init Job templates (create-database, migrate-database, create-importers)
- Aligns with the pattern already used in service Deployment templates

Fixes #94

**Jira:** [TC-4969](https://redhat.atlassian.net/browse/TC-4969)

## Test plan

- [ ] `helm template` with resource overrides on `createDatabase`, `migrateDatabase`, and `createImporters` renders valid YAML with `resources:` inside the container spec
- [ ] Templates render correctly without resource overrides (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4969]: https://redhat.atlassian.net/browse/TC-4969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Bug Fixes:
- Fix misaligned trustification.application.container helper in create-database, migrate-database, and create-importers Job templates to ensure properly nested container configuration.