### PR TITLE
feat: add pagination total cache TTL configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /.serena
+charts/*/tests/__snapshot__/

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -47,6 +47,22 @@ Lint like CI:
 ct lint --config .github/ct.yaml --all
  ```
 
+## Unit testing Helm templates
+
+Install the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin (one-time setup):
+
+```shell
+helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1 --verify=false
+```
+
+Run the tests:
+
+```shell
+helm unittest charts/trustify
+```
+
+Test files live in `charts/trustify/tests/` with the suffix `_test.yaml`.
+
 ## Find that whitespace
 
 ```shell

--- a/charts/trustify/templates/helpers/_deployment.tpl
+++ b/charts/trustify/templates/helpers/_deployment.tpl
@@ -78,3 +78,14 @@ resources:
 {{ end }}
 
 {{- end }}
+
+{{/*
+Cache time to live.
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.application.cache.ttl" }}
+{{- .Values.modules.server.cacheTTL }}
+{{- end }}

--- a/charts/trustify/templates/services/server/030-Deployment.yaml
+++ b/charts/trustify/templates/services/server/030-Deployment.yaml
@@ -54,6 +54,11 @@ spec:
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
             {{- include "trustification.oidc.swaggerUi" $mod | nindent 12 }}
 
+            {{- with (include "trustification.application.cache.ttl" . | trim) }}
+            - name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL
+              value: {{ . | quote }}
+            {{- end }}
+
             - name: UI_ISSUER_URL
               value: {{ include "trustification.oidc.frontendIssuerUrl" . }}
             - name: UI_CLIENT_ID

--- a/charts/trustify/tests/server_deployment_test.yaml
+++ b/charts/trustify/tests/server_deployment_test.yaml
@@ -1,0 +1,48 @@
+suite: server cacheTTL
+templates:
+  - templates/services/server/030-Deployment.yaml
+  - templates/services/server/020-ConfigMap-auth.yaml
+values:
+  - ../values.yaml
+  - ../../../values-minikube.yaml
+tests:
+  - it: should set TRUSTD_PAGINATION_TOTAL_CACHE_TTL to 60sec by default
+    template: templates/services/server/030-Deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL
+            value: "60sec"
+
+  - it: should respect custom cacheTTL value
+    template: templates/services/server/030-Deployment.yaml
+    set:
+      modules.server.cacheTTL: "120sec"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL
+            value: "120sec"
+
+  - it: should pass through different time unit unchanged
+    template: templates/services/server/030-Deployment.yaml
+    set:
+      modules.server.cacheTTL: "5min"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL
+            value: "5min"
+
+  - it: should omit env var when cacheTTL is empty
+    template: templates/services/server/030-Deployment.yaml
+    set:
+      modules.server.cacheTTL: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TRUSTD_PAGINATION_TOTAL_CACHE_TTL

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -244,6 +244,10 @@
                   "description": "The maximum number of the bytes the analysis cache will hold before evicting entries.\n",
                   "$ref": "#/definitions/ByteSize"
                 },
+                "cacheTTL": {
+                  "type": "string",
+                  "description": "the time a cache is allowed to live (in s) before forcing a reload.\n"
+                },
                 "readOnly": {
                   "type": "boolean",
                   "description": "Enable read-only mode. When true, the server rejects all mutating API\nrequests with 503 and the importer suspends all import jobs.\n"

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -216,6 +216,10 @@ properties:
                 description: |
                   The maximum number of the bytes the analysis cache will hold before evicting entries.
                 $ref: "#/definitions/ByteSize"
+              cacheTTL:
+                type: string
+                description: |
+                  the time a cache is allowed to live (in s) before forcing a reload.
               readOnly:
                 type: boolean
                 description: |

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -51,6 +51,7 @@ modules:
     tracing: {}
     metrics: {}
     rust: {}
+    cacheTTL: "60sec"
     resources:
       requests:
         cpu: 1


### PR DESCRIPTION
## Summary

- Add `trustification.application.cache.ttl` helper template to `_deployment.tpl` that returns `.Values.modules.server.cacheTTL`
- Add `TRUSTD_PAGINATION_TOTAL_CACHE_TTL` env var to the server Deployment using the new template
- Add `cacheTTL` default value (`"60sec"`) to `values.yaml` and schema

Implements [TC-5185](https://redhat.atlassian.net/browse/TC-5185)

## Test plan

- [x] `helm template` renders `TRUSTD_PAGINATION_TOTAL_CACHE_TTL` with default value `60sec`
- [x] `helm template --set modules.server.cacheTTL=120sec` overrides correctly
- [x] `helm lint` passes without errors

[TC-5185]: https://redhat.atlassian.net/browse/TC-5185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Configure server pagination total cache TTL via Helm values and expose it through a dedicated environment variable.

New Features:
- Introduce a configurable cacheTTL value for the server module with a default of 60 seconds.
- Add TRUSTD_PAGINATION_TOTAL_CACHE_TTL environment variable to the server deployment wired to the cacheTTL value.

Enhancements:
- Add a helper template to centralize application cache TTL resolution from Helm values.
- Extend the Helm values schema to document and validate the new cacheTTL configuration option.