### PR TITLE
test(chart): add proxy QE test environment for git-based importers

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,70 @@ modules:
     enabled: false
 ```
 
+## Proxy Testing (QE)
+
+The `values-proxy-test.yaml` file supports QE validation of git-based importer proxy
+auto-detection (TC-5174). It deploys a Squid forward proxy in-cluster and injects
+`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` into the importer pod via the `extraEnv` mechanism.
+
+### Deploy the proxy and network policy
+
+Apply these **before** deploying Trustify to avoid a race condition where the importer
+could reach github.com directly before the NetworkPolicy propagates:
+
+```bash
+oc apply -f squid-proxy.yaml -n $NAMESPACE
+oc apply -f networkpolicy-block-importer-egress.yaml -n $NAMESPACE
+```
+
+### Deploy with proxy test values
+
+```bash
+helm upgrade --install -n $NAMESPACE trustify charts/trustify \
+  --values values-ocp-no-aws.yaml \
+  --values values-proxy-test.yaml \
+  --set-string appDomain=$APP_DOMAIN \
+  --set image.fullName="<image-reference>"
+```
+
+### NO_PROXY configuration
+
+The default `NO_PROXY` in `values-proxy-test.yaml` contains only the minimal
+common baseline. You must extend it with infrastructure-specific hostnames to
+prevent internal traffic from routing through Squid.
+
+**OCP-only (bundled Keycloak + PostgreSQL):**
+
+Add the bundled service names and the Keycloak route FQDN:
+
+```bash
+--set 'modules.importer.extraEnv[2].name=NO_PROXY' \
+--set 'modules.importer.extraEnv[2].value=localhost,127.0.0.1,.svc,.cluster.local,trustify-server,infrastructure-postgresql,infrastructure-keycloak,sso-$NAMESPACE.$APP_DOMAIN'
+```
+
+**AWS (RDS + Cognito + S3):**
+
+Add the RDS endpoint hostname and the Cognito issuer hostname:
+
+```bash
+--set 'modules.importer.extraEnv[2].name=NO_PROXY' \
+--set 'modules.importer.extraEnv[2].value=localhost,127.0.0.1,.svc,.cluster.local,trustify-server,<RDS-endpoint>,<Cognito-issuer-hostname>'
+```
+
+For example:
+
+```bash
+--set 'modules.importer.extraEnv[2].value=localhost,127.0.0.1,.svc,.cluster.local,trustify-server,trustify-db.abc123.us-east-1.rds.amazonaws.com,cognito-idp.us-east-1.amazonaws.com'
+```
+
+| Infrastructure | Hostnames to add to NO_PROXY |
+|---|---|
+| Bundled PostgreSQL | `infrastructure-postgresql` |
+| Bundled Keycloak | `infrastructure-keycloak`, `sso-<namespace>.<appDomain>` |
+| AWS RDS | RDS endpoint (e.g., `trustify-db.abc123.us-east-1.rds.amazonaws.com`) |
+| AWS Cognito | Cognito issuer host (e.g., `cognito-idp.us-east-1.amazonaws.com`) |
+| AWS S3 | Not needed — S3 traffic should go through the proxy |
+
 ## Initial set of importers
 
 You can create an initial set of importers by adding the values file `values-importers.yaml`.

--- a/charts/trustify/templates/helpers/_extra.tpl
+++ b/charts/trustify/templates/helpers/_extra.tpl
@@ -21,3 +21,19 @@ Arguments (dict):
 {{- . | toYaml }}
 {{- end }}
 {{- end }}
+
+{{/*
+Additional environment variables
+
+Arguments (dict):
+  * root - .
+  * module - module object
+*/}}
+{{- define "trustification.application.extraEnv" }}
+{{- with .module.extraEnv }}
+{{- . | toYaml }}
+{{- end }}
+{{- with .root.Values.extraEnv }}
+{{- . | toYaml }}
+{{- end }}
+{{- end }}

--- a/charts/trustify/templates/services/importer/030-Deployment.yaml
+++ b/charts/trustify/templates/services/importer/030-Deployment.yaml
@@ -50,6 +50,7 @@ spec:
             {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.extraEnv" $mod | nindent 12 }}
 
           ports:
             {{- include "trustification.application.infrastructure.podPorts" $mod | nindent 12 }}

--- a/networkpolicy-block-importer-egress.yaml
+++ b/networkpolicy-block-importer-egress.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: block-importer-direct-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: importer
+  policyTypes:
+    - Egress
+  egress:
+    # Allow cluster DNS (CoreDNS)
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        - port: 5353
+          protocol: UDP
+        - port: 5353
+          protocol: TCP
+
+    # Allow Squid proxy
+    - to:
+        - podSelector:
+            matchLabels:
+              app: squid-proxy
+      ports:
+        - port: 3128
+          protocol: TCP
+
+    # Allow PostgreSQL
+    - ports:
+        - port: 5432
+          protocol: TCP
+
+    # Allow Keycloak (HTTPS)
+    - ports:
+        - port: 8443
+          protocol: TCP
+
+    # Allow Trustify server (HTTP + infrastructure)
+    - ports:
+        - port: 8080
+          protocol: TCP
+        - port: 9010
+          protocol: TCP

--- a/squid-proxy.yaml
+++ b/squid-proxy.yaml
@@ -26,8 +26,13 @@ data:
     access_log stdio:/dev/stdout
     cache_log stdio:/dev/stderr
 
+    # Run as non-root on OpenShift (arbitrary UID)
+    pid_filename /tmp/squid.pid
+    coredump_dir /tmp
+
     # Minimal caching — this is a test proxy, not a CDN
     cache deny all
+    cache_dir null /tmp
 
     # Disable via header to keep responses clean
     via off

--- a/squid-proxy.yaml
+++ b/squid-proxy.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: squid-config
+data:
+  squid.conf: |
+    # Restrict access to RFC1918 ranges (cluster pods only)
+    acl localnet src 10.0.0.0/8
+    acl localnet src 172.16.0.0/12
+    acl localnet src 192.168.0.0/16
+
+    acl SSL_ports port 443
+    acl Safe_ports port 80
+    acl Safe_ports port 443
+    acl CONNECT method CONNECT
+
+    http_access deny !Safe_ports
+    http_access deny CONNECT !SSL_ports
+    http_access allow localnet
+    http_access deny all
+
+    http_port 3128
+
+    # Log to stdout for oc logs visibility
+    access_log stdio:/dev/stdout
+    cache_log stdio:/dev/stderr
+
+    # Minimal caching — this is a test proxy, not a CDN
+    cache deny all
+
+    # Disable via header to keep responses clean
+    via off
+    forwarded_for delete
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: squid-proxy
+  labels:
+    app: squid-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: squid-proxy
+  template:
+    metadata:
+      labels:
+        app: squid-proxy
+    spec:
+      containers:
+        - name: squid
+          image: registry.redhat.io/rhel9/squid:5.5
+          ports:
+            - containerPort: 3128
+              protocol: TCP
+          volumeMounts:
+            - name: squid-config
+              mountPath: /etc/squid/squid.conf
+              subPath: squid.conf
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: squid-config
+          configMap:
+            name: squid-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: squid-proxy
+spec:
+  selector:
+    app: squid-proxy
+  ports:
+    - port: 3128
+      targetPort: 3128
+      protocol: TCP
+  type: ClusterIP

--- a/values-proxy-test.yaml
+++ b/values-proxy-test.yaml
@@ -1,0 +1,56 @@
+$schema: "charts/trustify/values.schema.json"
+
+appDomain: change-me
+tracing: {}
+metrics: {}
+
+# --- Infrastructure mode ---
+# OCP-only: use with  -f values-ocp-no-aws.yaml -f values-proxy-test.yaml
+# AWS:      use with  -f values-ocp-aws.yaml   -f values-proxy-test.yaml
+#
+# For AWS mode, update NO_PROXY below to include the Cognito issuer hostname
+# and RDS endpoint hostname.
+
+# --- Image override ---
+# 2.2.5 (buggy — negative baseline):
+#   --set image.fullName="registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:fbc4a7fbc48d1888c314de042fdce35a213aa0d12dce1c097fbac7eb1ad1a2d1"
+#
+# 2.2.6 (fixed — positive test):
+#   --set image.fullName="registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4d024a6b748997b2cc757f53a7f0c3fe7f80789b74f7325837d93ecd0273bb58"
+
+modules:
+  importer:
+    enabled: true
+    extraEnv:
+      - name: HTTP_PROXY
+        value: "http://squid-proxy:3128"
+      - name: HTTPS_PROXY
+        value: "http://squid-proxy:3128"
+      # Adjust NO_PROXY for your infrastructure mode:
+      #
+      # OCP-only (bundled Keycloak + PostgreSQL):
+      #   localhost,127.0.0.1,.svc,.cluster.local,infrastructure-postgresql,infrastructure-keycloak,trustify-server
+      #   Also append the Keycloak route FQDN: sso-<namespace>.apps.<cluster-domain>
+      #
+      # AWS (RDS + Cognito + S3):
+      #   localhost,127.0.0.1,.svc,.cluster.local,trustify-server,<RDS-endpoint>,<Cognito-issuer-hostname>
+      #   e.g., trustify-db.abc123.us-east-1.rds.amazonaws.com,cognito-idp.us-east-1.amazonaws.com
+      - name: NO_PROXY
+        value: "localhost,127.0.0.1,.svc,.cluster.local,trustify-server"
+
+  createImporters:
+    enabled: true
+    importers:
+      cve:
+        cve:
+          description: CVE list v5
+          period: 1d
+          source: https://github.com/CVEProject/cvelistV5
+          disabled: false
+      osv-github:
+        osv:
+          description: GitHub Advisory Database
+          period: 1d
+          source: https://github.com/github/advisory-database
+          path: advisories
+          disabled: false

--- a/values-proxy-test.yaml
+++ b/values-proxy-test.yaml
@@ -12,11 +12,13 @@ metrics: {}
 # and RDS endpoint hostname.
 
 # --- Image override ---
-# 2.2.5 (buggy — negative baseline):
-#   --set image.fullName="registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:fbc4a7fbc48d1888c314de042fdce35a213aa0d12dce1c097fbac7eb1ad1a2d1"
+# Switch between 2.2.5 (buggy) and 2.2.6 (fixed) by uncommenting one block:
 #
-# 2.2.6 (fixed — positive test):
-#   --set image.fullName="registry.redhat.io/rhtpa/rhtpa-trustification-service-rhel9@sha256:4d024a6b748997b2cc757f53a7f0c3fe7f80789b74f7325837d93ecd0273bb58"
+image:
+  fullName: change-me
+  pullPolicy: IfNotPresent
+  name: null
+  registry: null
 
 modules:
   importer:
@@ -54,3 +56,19 @@ modules:
           source: https://github.com/github/advisory-database
           path: advisories
           disabled: false
+      redhat-sboms:
+        sbom:
+          description: All Red Hat SBOMs
+          period: 1d
+          source: https://security.access.redhat.com/data/sbom/v1/
+          keys:
+            - https://security.access.redhat.com/data/97f5eac4.txt#77E79ABE93673533ED09EBE2DCE3823597F5EAC4
+          disabled: false
+          fetchRetries: 50
+      redhat-csaf:
+        csaf:
+          description: All Red Hat CSAF data
+          period: 1d
+          source: redhat.com
+          disabled: false
+          fetchRetries: 50


### PR DESCRIPTION
Add test infrastructure to validate that git-based importers (CVE, OSV-GitHub) properly route through a forward proxy after the ProxyOptions::auto() fix. Includes:

- extraEnv Helm helper for injecting HTTP_PROXY/HTTPS_PROXY/NO_PROXY into the importer deployment via values
- Squid forward proxy manifest (registry.redhat.io/rhel9/squid:5.5) with ACL restricted to RFC1918 ranges
- NetworkPolicy blocking importer direct egress to force traffic through the proxy
- values-proxy-test.yaml with git-based importers and proxy env vars
- README section documenting NO_PROXY configuration for OCP and AWS infrastructure modes

Implements TC-5205

Assisted-by: Claude Code

## Summary by Sourcery

Add QE-focused proxy testing support for git-based importers by introducing configurable extra environment variables, proxy/network policy manifests, and documentation.

New Features:
- Allow importer deployments to receive additional environment variables via chart values, including proxy configuration for git-based importers.

Enhancements:
- Provide a Squid-based in-cluster forward proxy and a NetworkPolicy that forces importer egress through the proxy for validation scenarios.
- Add a proxy test values file that enables git-based importers with proxy settings tailored for different infrastructure modes (OCP-only and AWS).

Documentation:
- Document QE proxy testing workflow, including deployment steps and NO_PROXY configuration guidance for OCP and AWS setups.

Tests:
- Introduce dedicated Helm values and Kubernetes resources to support QE validation of proxy auto-detection for git-based importers.