### PR TITLE
feat: add first-class HTTP proxy support for importer

### DIFF
--- a/charts/trustify/templates/helpers/_proxy.tpl
+++ b/charts/trustify/templates/helpers/_proxy.tpl
@@ -9,13 +9,19 @@ Arguments (dict):
 {{- with .httpProxy }}
 - name: HTTP_PROXY
   value: {{ . | quote }}
+- name: http_proxy
+  value: {{ . | quote }}
 {{- end }}
 {{- with .httpsProxy }}
 - name: HTTPS_PROXY
   value: {{ . | quote }}
+- name: https_proxy
+  value: {{ . | quote }}
 {{- end }}
 {{- with .noProxy }}
 - name: NO_PROXY
+  value: {{ . | quote }}
+- name: no_proxy
   value: {{ . | quote }}
 {{- end }}
 {{- end }}

--- a/charts/trustify/templates/helpers/_proxy.tpl
+++ b/charts/trustify/templates/helpers/_proxy.tpl
@@ -1,0 +1,22 @@
+{{/*
+Proxy env-vars for containers that need HTTP proxy support.
+
+Arguments (dict):
+  * root - .
+*/}}
+{{- define "trustification.application.proxy.envVars" -}}
+{{- with .root.Values.proxy }}
+{{- with .httpProxy }}
+- name: HTTP_PROXY
+  value: {{ . | quote }}
+{{- end }}
+{{- with .httpsProxy }}
+- name: HTTPS_PROXY
+  value: {{ . | quote }}
+{{- end }}
+{{- with .noProxy }}
+- name: NO_PROXY
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/trustify/templates/services/importer/030-Deployment.yaml
+++ b/charts/trustify/templates/services/importer/030-Deployment.yaml
@@ -50,6 +50,7 @@ spec:
             {{- include "trustification.application.readOnly.envVars" $mod | nindent 12 }}
             {{- include "trustification.postgres.envVars" (dict "root" . "database" .Values.database) | nindent 12 }}
             {{- include "trustification.storage.envVars" $mod | nindent 12 }}
+            {{- include "trustification.application.proxy.envVars" $mod | nindent 12 }}
 
           ports:
             {{- include "trustification.application.infrastructure.podPorts" $mod | nindent 12 }}

--- a/charts/trustify/tests/importer_deployment_test.yaml
+++ b/charts/trustify/tests/importer_deployment_test.yaml
@@ -20,12 +20,27 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: http_proxy
+            value: "http://squid:3128"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: HTTPS_PROXY
             value: "http://squid:3128"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: https_proxy
+            value: "http://squid:3128"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NO_PROXY
+            value: "localhost,127.0.0.1"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: no_proxy
             value: "localhost,127.0.0.1"
 
   - it: should omit proxy env vars when proxy is empty
@@ -39,12 +54,27 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
+            name: http_proxy
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: HTTPS_PROXY
           any: true
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
+            name: https_proxy
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NO_PROXY
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: no_proxy
           any: true
 
   - it: should inject only HTTP_PROXY when only httpProxy is set
@@ -57,6 +87,11 @@ tests:
           content:
             name: HTTP_PROXY
             value: "http://squid:3128"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: http_proxy
+            value: "http://squid:3128"
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
@@ -65,5 +100,15 @@ tests:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
+            name: https_proxy
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: NO_PROXY
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: no_proxy
           any: true

--- a/charts/trustify/tests/importer_deployment_test.yaml
+++ b/charts/trustify/tests/importer_deployment_test.yaml
@@ -1,0 +1,69 @@
+suite: importer proxy env vars
+templates:
+  - templates/services/importer/030-Deployment.yaml
+values:
+  - ../values.yaml
+  - ../../../values-minikube.yaml
+tests:
+  - it: should inject all proxy env vars when proxy is configured
+    template: templates/services/importer/030-Deployment.yaml
+    set:
+      proxy.httpProxy: "http://squid:3128"
+      proxy.httpsProxy: "http://squid:3128"
+      proxy.noProxy: "localhost,127.0.0.1"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_PROXY
+            value: "http://squid:3128"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: "http://squid:3128"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NO_PROXY
+            value: "localhost,127.0.0.1"
+
+  - it: should omit proxy env vars when proxy is empty
+    template: templates/services/importer/030-Deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_PROXY
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NO_PROXY
+          any: true
+
+  - it: should inject only HTTP_PROXY when only httpProxy is set
+    template: templates/services/importer/030-Deployment.yaml
+    set:
+      proxy.httpProxy: "http://squid:3128"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_PROXY
+            value: "http://squid:3128"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NO_PROXY
+          any: true

--- a/charts/trustify/values.schema.json
+++ b/charts/trustify/values.schema.json
@@ -179,6 +179,9 @@
         }
       }
     },
+    "proxy": {
+      "$ref": "#/definitions/ProxyConfig"
+    },
     "rust": {
       "$ref": "#/definitions/RustApplicationConfig"
     },
@@ -456,6 +459,25 @@
     }
   ],
   "definitions": {
+    "ProxyConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "HTTP proxy configuration. When set, the corresponding environment variables\n(HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are injected into the importer container.\n",
+      "properties": {
+        "httpProxy": {
+          "type": "string",
+          "description": "HTTP proxy URL (sets HTTP_PROXY)"
+        },
+        "httpsProxy": {
+          "type": "string",
+          "description": "HTTPS proxy URL (sets HTTPS_PROXY)"
+        },
+        "noProxy": {
+          "type": "string",
+          "description": "Comma-separated list of hosts to bypass the proxy (sets NO_PROXY)"
+        }
+      }
+    },
     "Scalable": {
       "description": "Configuration options for a scalable deployment.\n",
       "allOf": [

--- a/charts/trustify/values.schema.yaml
+++ b/charts/trustify/values.schema.yaml
@@ -177,6 +177,9 @@ properties:
         description: |
           OpenTelemetry collector endpoint for tracing and metrics.
 
+  proxy:
+    $ref: "#/definitions/ProxyConfig"
+
   rust:
     $ref: "#/definitions/RustApplicationConfig"
 
@@ -352,6 +355,23 @@ allOf:
 # all the definitions
 
 definitions:
+
+  ProxyConfig:
+    type: object
+    additionalProperties: false
+    description: |
+      HTTP proxy configuration. When set, the corresponding environment variables
+      (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) are injected into the importer container.
+    properties:
+      httpProxy:
+        type: string
+        description: HTTP proxy URL (sets HTTP_PROXY)
+      httpsProxy:
+        type: string
+        description: HTTPS proxy URL (sets HTTPS_PROXY)
+      noProxy:
+        type: string
+        description: Comma-separated list of hosts to bypass the proxy (sets NO_PROXY)
 
   Scalable:
     description: |

--- a/charts/trustify/values.yaml
+++ b/charts/trustify/values.yaml
@@ -9,6 +9,8 @@ image:
 
 rust: {}
 
+proxy: {}
+
 readOnly: false
 
 ingress:


### PR DESCRIPTION
Add top-level proxy configuration (httpProxy, httpsProxy, noProxy) that injects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY env vars into the importer container. Required for environments where direct egress to github.com is blocked and git operations must route through a proxy.

## Summary by Sourcery

Add configurable HTTP proxy support for the importer by introducing a top-level proxy configuration that maps to standard proxy environment variables.

New Features:
- Introduce a ProxyConfig values section to configure HTTP, HTTPS, and no-proxy settings for the importer.
- Inject HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables into the importer deployment when proxy values are provided.

Tests:
- Add Helm unit tests to verify proxy environment variables are injected or omitted in the importer deployment based on proxy configuration.