### PR TITLE
TC-5399: Add helm-unittest CI integration to GitHub Actions workflow

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -53,3 +53,16 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml --all
+
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.13.3
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.0.3
+      - name: Run trustify chart unit tests
+        run: helm unittest --failfast charts/trustify


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Integrate helm-unittest into the GitHub Actions lint-test workflow as a separate unittest job that sets up Helm, installs the plugin, and executes chart unit tests.